### PR TITLE
Fix path issue on Windows versions of meteor.

### DIFF
--- a/plugin/import-gtfs.js
+++ b/plugin/import-gtfs.js
@@ -53,6 +53,6 @@ Plugin.registerSourceHandler("gtfs.zip", function (compileStep) {
     compileStep.addJavaScript({
         path: path.join(path_part, 'gtfs.' + basename + '.js'),
         sourcePath: compileStep.inputPath,
-        data: "GTFS.importFromZip('" + templateName + "', '" + compileStep._fullInputPath + "');",
+        data: 'GTFS.importFromZip("' + templateName + '", "' + compileStep._fullInputPath.replace(/\\/g, "\\\\") + '");'
     });
 });


### PR DESCRIPTION
Fixes #1 

Should still work on posix based paths as `/` isn't treated as an escape character. 
